### PR TITLE
replaced datetime function

### DIFF
--- a/_bots.py
+++ b/_bots.py
@@ -115,7 +115,7 @@ class bot:
         self.token = ''
         self.clientId = ''
         self.queue = queue
-        self.epoch = int(datetime.datetime.now().strftime("%s"))
+        self.epoch = int(datetime.datetime.now().timestamp())
 
     def connect(self):
         try:

--- a/flood.py
+++ b/flood.py
@@ -4,11 +4,13 @@ import datetime
 from threading import *
 from pyfiglet import Figlet
 import queue
+import os
 
 from _token import *
 from _payload import *
 from _functions import *
 from _bots import *
+
 from _ui import *
 
 q = queue.Queue()
@@ -50,7 +52,8 @@ while True:
             glitchname = True
         else:
             glitchname = False
-    epoch = int(datetime.datetime.now().strftime("%s"))
+
+    epoch = int(datetime.datetime.now().timestamp())
     r = requests.get(f'https://kahoot.it/reserve/session/{pin}/?{epoch}')
     if r.status_code != 200:
         print('Incorrect PIN')

--- a/flood.py
+++ b/flood.py
@@ -4,7 +4,6 @@ import datetime
 from threading import *
 from pyfiglet import Figlet
 import queue
-import os
 
 from _token import *
 from _payload import *


### PR DESCRIPTION
  File "flood.py", line 56, in <module>
    epoch = int(datetime.datetime.now().strftime("%s"))
ValueError: Invalid format string

Hi I used your script recently, but I ran onto an error in Windows. I tried it on mac and it worked perfectly fine. 
Although the script works on Mac, on Windows the error above pops up. Using.strftime("%s") should be avoided because it is not supported and it is not portable. 
You should add a note in the README: pip install windows-curses if a someone is going to run the script in Windows. Awesome script btw! 